### PR TITLE
deactivate default true for cert-manager and reward-ingress

### DIFF
--- a/wms-enabled-application/values.yaml
+++ b/wms-enabled-application/values.yaml
@@ -47,9 +47,9 @@ ingress:
   ingressclass: nginx-c3s
 
   # set certManagerCertificateRequest to "true" and certManager parameters to use cert-manager and acme challenge
-  certManagerCertificateRequest: true
-  certManager:
-    clusterIssuer: letsencrypt-c3s # Cluster issuer to use for SSL certificates
-    issueTemporaryCertificate: false # Set to true to issue a temporary certificate
-    acme: true # Set to true to use ACME for certificate issuance
-    disableSslRedirect: false # Set to true to disable SSL redirect
+  # certManagerCertificateRequest: true
+  # certManager:
+  #   clusterIssuer: letsencrypt-c3s # Cluster issuer to use for SSL certificates
+  #   issueTemporaryCertificate: false # Set to true to issue a temporary certificate
+  #   acme: true # Set to true to use ACME for certificate issuance
+  #   disableSslRedirect: false # Set to true to disable SSL redirect


### PR DESCRIPTION
ecde-solver reward-ingress was setted default to `true` in the `values.yaml`

Now it's commented and should be activated only if needed