### PR TITLE
add(wms-ready-application): new deployment Chart for all apps

### DIFF
--- a/wms-ready-application/.helmignore
+++ b/wms-ready-application/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/wms-ready-application/Chart.yaml
+++ b/wms-ready-application/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+name: WMS-ready Application
+description: A Helm chart for deploying a WMS-ready application for C3S projects
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"

--- a/wms-ready-application/templates/_helpers.tpl
+++ b/wms-ready-application/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "wms-ready.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "wms-ready.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "wms-ready.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "wms-ready.labels" -}}
+helm.sh/chart: {{ include "wms-ready.chart" . }}
+{{ include "wms-ready.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "wms-ready.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "wms-ready.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "wms-ready.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "wms-ready.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/wms-ready-application/templates/api-service.yaml
+++ b/wms-ready-application/templates/api-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}-api
+spec:
+  selector:
+    component: api
+  type: ClusterIP
+  ports:
+    - name: api-port
+      port: {{ .Values.apiServer.port }}
+      targetPort: {{ .Values.apiServer.port }}

--- a/wms-ready-application/templates/api.yaml
+++ b/wms-ready-application/templates/api.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}-api
+spec:
+  replicas: {{ .Values.apiServer.replicas }}
+  selector:
+    matchLabels:
+      component: api
+      app: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        component: api
+        app: {{ .Values.name }}
+    spec:
+      containers:
+        - args:
+          - bash
+          - -c
+          - {{ .Values.apiServer.startupCommand }}
+          name: {{ .Values.name }}-api
+          image: {{ .Values.apiServer.image }}:{{ .Values.apiServer.tag }}
+          ports:
+            - containerPort: {{ .Values.apiServer.port }}
+          env:
+            - name: ROOT_PATH
+              value: {{ .Values.apiServer.env.rootPath }}
+            - name: MODE
+              value: {{ .Values.apiServer.env.mode }}
+            {{- if .Values.apiServer.env.allowedOrigin }}
+            - name: ALLOWED_ORIGIN
+              value: {{ .Values.apiServer.env.allowedOrigin }}
+            {{- end }}
+            - name: WMS_SERVER
+            {{- if .Values.localDevelopment }}
+              value: {{ .Values.apiServer.env.wmsServer }}:$({{ .Values.name | upper }}_WMS_SERVICE_PORT_WMS_PORT)
+            {{ else }}
+              value: {{ .Values.apiServer.env.wmsServer }}
+            {{ end }}
+            - name: WMS_DATA_DIR
+              value: {{ .Values.commonWms.env.wmsDataDir }}
+            - name: WMS_STYLE_DIR
+              value: {{ .Values.commonWms.env.wmsStyleDir }}
+{{- if .Values.sharedPvc }}
+          volumeMounts:
+          - mountPath: {{ .Values.sharedPvc.path }}
+            name: {{ .Values.sharedPvc.name }}
+      volumes:
+      - name: {{ .Values.sharedPvc.name }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.sharedPvc.name }}
+{{- end }}

--- a/wms-ready-application/templates/harbor-pull-secret.yaml
+++ b/wms-ready-application/templates/harbor-pull-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: harborpullsecret
+data:
+  .dockerconfigjson: ewoJImF1dGhzIjogewoJCSJlY2NyLmVjbXdmLmludCI6IHsKCQkJImF1dGgiOiAiY205aWIzUWtZMkZrY3l0allXUnpMWEp2WW05ME9sVlBZMUpGVkhCVWFXVTJXWGw1U1ZaV1Yya3ljVEJUYm1kUWRHVlNja3BEIgoJCX0KCX0KfQo=
+type: kubernetes.io/dockerconfigjson

--- a/wms-ready-application/templates/harbor-pull-secret.yaml
+++ b/wms-ready-application/templates/harbor-pull-secret.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: harborpullsecret
-data:
-  .dockerconfigjson: ewoJImF1dGhzIjogewoJCSJlY2NyLmVjbXdmLmludCI6IHsKCQkJImF1dGgiOiAiY205aWIzUWtZMkZrY3l0allXUnpMWEp2WW05ME9sVlBZMUpGVkhCVWFXVTJXWGw1U1ZaV1Yya3ljVEJUYm1kUWRHVlNja3BEIgoJCX0KCX0KfQo=
-type: kubernetes.io/dockerconfigjson

--- a/wms-ready-application/templates/ingress.yaml
+++ b/wms-ready-application/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enable }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.name }}
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128K"
+    nginx.ingress.kubernetes.io/proxy-buffers-number: "4 256k"
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "120"
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  tls:
+    - hosts:
+        - {{ .Values.ingress.hostname }}
+      secretName: {{ .Values.ingress.secretName }}
+  rules:
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            path: {{ .Values.ingress.apiPath }}(.*)
+            backend:
+              service:
+                name: {{ .Values.name }}-api
+                port:
+                  number: 5000
+          - pathType: ImplementationSpecific
+            path: {{ .Values.ingress.wmsPath }}(.*)
+            backend:
+              service:
+                name: {{ .Values.name }}-wms
+                port:
+                  number: 5000
+          - pathType: ImplementationSpecific
+            path: {{ .Values.ingress.webappPath }}(.*)
+            backend:
+              service:
+                name: {{ .Values.name }}-webapp
+                port:
+                  number: 80
+  ingressClassName: {{ .Values.ingress.ingressclass }}
+{{- end }}

--- a/wms-ready-application/templates/pv.yaml
+++ b/wms-ready-application/templates/pv.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.sharedPvc }}
+{{- if .Values.sharedPvc.pvName }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  annotations:
+    pv.kubernetes.io/provisioned-by: nfs.csi.k8s.io
+  name: {{ .Values.sharedPvc.pvName }}
+spec:
+  capacity:
+    storage: {{ .Values.sharedPvc.storage }}
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: {{ .Values.sharedPvc.storageclass }}
+  mountOptions:
+    - nfsvers=4.1
+  csi:
+    driver: nfs.csi.k8s.io
+    # volumeHandle format: {nfs-server-address}#{sub-dir-name}#{share-name}
+    # make sure this value is unique for every share in the cluster
+    volumeHandle: {{ .Values.sharedPvc.nfsServerUrl }}/share##
+    volumeAttributes:
+      server: {{ .Values.sharedPvc.nfsServerUrl }}
+      share: /
+{{- end }}
+{{- end }}

--- a/wms-ready-application/templates/pvc.yaml
+++ b/wms-ready-application/templates/pvc.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.sharedPvc }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.sharedPvc.name }}
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.sharedPvc.storage }}
+  {{- if .Values.sharedPvc.pvName }}
+  volumeName: {{ .Values.sharedPvc.pvName }}
+  {{- end }}
+  storageClassName: {{ .Values.sharedPvc.storageclass }}
+{{- end }}

--- a/wms-ready-application/templates/reward-ingress.yaml
+++ b/wms-ready-application/templates/reward-ingress.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.ingress.certManagerCertificateRequest }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.clusterIssuer }}
+    {{- if .Values.ingress.issueTemporaryCertificate }}
+    cert-manager.io/issue-temporary-certificate: "true"
+    {{- end }}
+    {{- if .Values.ingress.acme }}
+    acme.cert-manager.io/http01-edit-in-place: "true"
+    {{- end }}
+    {{- if .Values.ingress.disableSslRedirect }}
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    {{- end }}
+  name: {{ .Values.name }}-solver
+spec:
+  ingressClassName: {{ .Values.ingress.ingressclass }}
+  rules:
+  - host: {{ .Values.ingress.hostname }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ .Values.name }}-webapp
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - {{ .Values.ingress.hostname }}
+    secretName: {{ .Values.ingress.secretName }}
+{{- end}}

--- a/wms-ready-application/templates/webapp-service.yaml
+++ b/wms-ready-application/templates/webapp-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}-webapp
+spec:
+  selector:
+    component: webapp
+  type: ClusterIP
+  ports:
+    - name: webapp-port
+      port: 80
+      targetPort: {{ .Values.webapp.port }}

--- a/wms-ready-application/templates/webapp.yaml
+++ b/wms-ready-application/templates/webapp.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}-webapp
+spec:
+  replicas: {{ .Values.webapp.replicas }}
+  selector:
+    matchLabels:
+      component: webapp
+      app: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        component: webapp
+        app: {{ .Values.name }}
+    spec:
+      containers:
+        - name: {{ .Values.name }}-webapp
+          image: {{ .Values.webapp.image }}:{{ .Values.webapp.tag }}
+          ports:
+            - containerPort: {{ .Values.webapp.port }}

--- a/wms-ready-application/templates/wms-service.yaml
+++ b/wms-ready-application/templates/wms-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}-wms
+spec:
+  selector:
+    component: wms
+  type: ClusterIP
+  ports:
+    - name: wms-port
+      port: {{ .Values.wms.port }}
+      targetPort: {{ .Values.wms.port }}

--- a/wms-ready-application/templates/wms.yaml
+++ b/wms-ready-application/templates/wms.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}-wms
+spec:
+  replicas: {{ .Values.wms.replicas }}
+  selector:
+    matchLabels:
+      component: wms
+      app: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        component: wms
+        app: {{ .Values.name }}
+    spec:
+      containers:
+        - name: {{ .Values.name }}-wms
+          args:
+          - bash
+          - -c
+          - while true; do if [ -f {{ .Values.commonWms.env.wmsDataDir }}/.completed.txt ]; then echo ".completed.txt found"; break; else echo "Waiting for .completed.txt creation..."; sleep 1; fi; done; echo "Verification succeeded!" && uwsgi --http 0.0.0.0:$WMS_PORT --master --mount /=skinnywms.wmssvr:application --env SKINNYWMS_DATA_PATH=./$WMS_DATA --env MAGICS_STYLE_PATH=./$WMS_STYLES
+          image: {{ .Values.wms.image }}:{{ .Values.wms.tag }}
+          ports:
+            - containerPort: {{ .Values.wms.port }}
+          env:
+          - name: WMS_PORT
+            value: $({{ .Values.name | upper }}_WMS_SERVICE_PORT_WMS_PORT)
+          - name: WMS_DATA
+            value: {{ .Values.commonWms.env.wmsDataDir }}
+          - name: WMS_STYLES
+            value: {{ .Values.commonWms.env.wmsStyleDir }}
+{{- if .Values.sharedPvc }}
+          volumeMounts:
+          - mountPath: {{ .Values.sharedPvc.path }}
+            name: {{ .Values.sharedPvc.name }}
+      volumes:
+      - name: {{ .Values.sharedPvc.name }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.sharedPvc.name }}
+{{- end }}

--- a/wms-ready-application/values.yaml
+++ b/wms-ready-application/values.yaml
@@ -1,0 +1,56 @@
+# Name of application
+name: wms-ready-application # Name of application
+localDevelopment: false
+webapp:
+  image: eccr.ecmwf.int/c3s-applications/wms-ready-application-webapp  # image for application
+  tag: latest # image tag to use (this )
+  port: 80  # Port exposed by the application
+  replicas: 1
+apiServer:
+  image: eccr.ecmwf.int/c3s-applications/wms-ready-application-server  # image for application
+  tag: latest  # image tag to use (this )
+  port: 5000 # Port exposed by the application
+  replicas: 1
+  startupCommand: "make start-server API_HOST=0.0.0.0 ROOT_PATH=$ROOT_PATH"
+  env:
+    wmsServer: https://apps.copernicus-climate.eu/c3s-apps/wms-ready-application/wms
+    rootPath: /c3s-apps/wms-ready-application/api
+    mode: production
+wms:
+  image: ecmwf/skinnywms  # image for application
+  tag: 0.10.0  # image tag to use (this )
+  port: 5000  # Port exposed by the application
+  replicas: 1
+  env:
+    skinnywmsUwsgiWorkers: $(SKINNYWMS_UWSGI_WORKERS:-4)
+commonWms:
+  env:
+    wmsDataDir: /skinnywms/appdata
+    wmsStyleDir: /skinnywms/styles
+# sharedPvc:
+#   name: wms-data-volume
+#   pvName: pv-wms
+#   nfsServerUrl: nfs-server.nfs-server.svc.cluster.local
+#   storage: 10Gi
+#   storageclass: nfs-csi
+#   path: /skinnywms
+# Values used for ingress control
+ingress:
+  enable: true
+  # Hostname where the app will be published, this must be mapped to the cluster described by the KUBECONFIG
+  hostname: apps.copernicus-climate.eu  
+  # Path to the application, this must be included in the env when building a JS application
+  webappPath: /c3s-apps/wms-ready-application/
+  apiPath: /c3s-apps/wms-ready-application/api/
+  wmsPath: /c3s-apps/wms-ready-application/wms/
+  # SSL certificate secret name:
+  secretName: cert-manager-c3s-cert
+  ingressclass: your-ingress-class
+
+# set certManagerCertificateRequest to "true" and certManager parameters to use cert-manager and acme challenge
+# certManagerCertificateRequest: false
+# certManager:
+#   clusterIssuer: letsencrypt-c3s # Cluster issuer to use for SSL certificates
+#   issueTemporaryCertificate: false # Set to true to issue a temporary certificate
+#   acme: true # Set to true to use ACME for certificate issuance
+#   disableSslRedirect: false # Set to true to disable SSL redirect

--- a/wms-ready-application/values/ecde/values-default.yaml
+++ b/wms-ready-application/values/ecde/values-default.yaml
@@ -1,0 +1,48 @@
+# Name of application
+name: ecde # Name of application
+localDevelopment: false
+webapp:
+  image: eccr.ecmwf.int/c3s-applications/ecde-webapp  # image for application
+  tag: latest # image tag to use (this )
+  port: 80  # Port exposed by the application
+  replicas: 1
+apiServer:
+  image: eccr.ecmwf.int/c3s-applications/ecde-server  # image for application
+  tag: latest  # image tag to use (this )
+  port: 5000 # Port exposed by the application
+  replicas: 1
+  startupCommand: cp -r ./european_climate_data_explorer/skinnywms/* /skinnywms/ && python3 european_climate_data_explorer/preload_wms.py && make start-server API_HOST=0.0.0.0 ROOT_PATH=$ROOT_PATH
+  env:
+    wmsServer: https://ecds-dev.bopen.compute.cci2.ecmwf.int/c3s-apps/ecde/wms
+    rootPath: /c3s-apps/ecde/api
+    mode: production
+wms:
+  image: ecmwf/skinnywms  # image for application
+  tag: 0.10.0  # image tag to use (this )
+  port: 5000  # Port exposed by the application
+  replicas: 1
+  env:
+    skinnywmsUwsgiWorkers: $(SKINNYWMS_UWSGI_WORKERS:-4)
+commonWms:
+  env:
+    wmsDataDir: /skinnywms/appdata
+    wmsStyleDir: /skinnywms/styles
+sharedPvc:
+  name: wms-data-volume
+  pvName: pv-wms
+  nfsServerUrl: nfs-server.nfs-server.svc.cluster.local
+  storage: 10Gi
+  storageclass: nfs-csi
+  path: /skinnywms
+# Values used for ingress control
+ingress:
+  enable: true
+  # Hostname where the app will be published, this must be mapped to the cluster described by the KUBECONFIG
+  hostname: ecds-dev.bopen.compute.cci2.ecmwf.int  
+  # Path to the application, this must be included in the env when building a JS application
+  webappPath: /c3s-apps/ecde/
+  apiPath: /c3s-apps/ecde/api/ 
+  wmsPath: /c3s-apps/ecde/wms/ 
+  # SSL certificate secret name:
+  secretName: cert-manager-c3s-cert
+  ingressclass: nginx-c3s

--- a/wms-ready-application/values/ecde/values-prod.yaml
+++ b/wms-ready-application/values/ecde/values-prod.yaml
@@ -1,0 +1,47 @@
+# Name of application
+name: ecde # Name of application
+localDevelopment: false
+webapp:
+  image: eccr.ecmwf.int/c3s-applications/ecde-webapp  # image for application
+  tag: latest  # image tag to use (this )
+  port: 80  # Port exposed by the application
+  replicas: 1
+apiServer:
+  image: eccr.ecmwf.int/c3s-applications/ecde-server  # image for application
+  tag: latest  # image tag to use (this )
+  port: 5000 # Port exposed by the application
+  replicas: 1
+  startupCommand: cp -r ./european_climate_data_explorer/skinnywms/* /skinnywms/ && python3 european_climate_data_explorer/preload_wms.py && make start-server API_HOST=0.0.0.0 ROOT_PATH=$ROOT_PATH
+  env:
+    wmsServer: https://ecds-dev-cci2.copernicus-climate.eu/c3s-apps/ecde/wms
+    rootPath: /c3s-apps/ecde/api
+    mode: production
+wms:
+  image: ecmwf/skinnywms  # image for application
+  tag: 0.10.0  # image tag to use (this )
+  port: 5000  # Port exposed by the application
+  replicas: 0
+  env:
+    skinnywmsUwsgiWorkers: $(SKINNYWMS_UWSGI_WORKERS:-4)
+commonWms:
+  env:
+    wmsDataDir: /skinnywms/appdata
+    wmsStyleDir: /skinnywms/styles
+sharedPvc:
+  name: wms-data-volume
+  storage: 10Gi
+  storageclass: cinder-csi
+  path: /skinnywms
+# Values used for ingress control
+ingress:
+  enable: true
+  # Hostname where the app will be published, this must be mapped to the cluster described by the KUBECONFIG
+  hostname: ecds-dev-cci2.copernicus-climate.eu  
+  # Path to the application, this must be included in the env when building a JS application
+  webappPath: /c3s-apps/ecde/
+  apiPath: /c3s-apps/ecde/api/ 
+  wmsPath: /c3s-apps/ecde/wms/ 
+  # SSL certificate secret name:
+  secretName: star.copernicus-climate.eu
+  ingressclass: nginx-dev
+  

--- a/wms-ready-application/values/ecde/values-remote.yaml
+++ b/wms-ready-application/values/ecde/values-remote.yaml
@@ -1,0 +1,56 @@
+# Name of application
+name: ecde # Name of application
+localDevelopment: true
+webapp:
+  image: eccr.ecmwf.int/c3s-applications/ecde-webapp  # image for application
+  tag: test  # image tag to use (this )
+  port: 80  # Port exposed by the application
+  replicas: 1
+apiServer:
+  image: eccr.ecmwf.int/c3s-applications/ecde-server  # image for application
+  tag: latest  # image tag to use (this )
+  port: 5000 # Port exposed by the application
+  replicas: 1
+  startupCommand: cp -r ./european_climate_data_explorer/skinnywms/* /skinnywms/ && python3 european_climate_data_explorer/preload_wms.py && make start-server API_HOST=0.0.0.0 ROOT_PATH=$ROOT_PATH
+  env:
+    rootPath: /
+    wmsServer: http://localhost
+    mode: production
+    allowedOrigin: http://localhost:8080
+wms:
+  image: ecmwf/skinnywms  # image for application
+  tag: 0.10.0  # image tag to use (this )
+  port: 5001  # Port exposed by the application
+  replicas: 1
+  env:
+    skinnywmsUwsgiWorkers: $(SKINNYWMS_UWSGI_WORKERS:-4)
+commonWms:
+  env:
+    wmsDataDir: /skinnywms/appdata
+    wmsStyleDir: /skinnywms/styles
+sharedPvc:
+  name: wms-data-volume
+  pvName: pv-wms
+  storage: 10Gi
+  storageclass: nfs-csi
+  path: /skinnywms
+# Values used for ingress control
+ingress:
+  enable: false
+  # Hostname where the app will be published, this must be mapped to the cluster described by the KUBECONFIG
+  hostname: ecds-dev-cci2.copernicus-climate.eu  
+  # Path to the application, this must be included in the env when building a JS application
+  webappPath: /c3s-apps/ecde/
+  apiPath: /c3s-apps/ecde/api/ 
+  wmsPath: /c3s-apps/ecde/wms/ 
+  # SSL certificate secret name:
+  secretName: star.copernicus-climate.eu
+  ingressclass: nginx-dev
+
+# set certManagerCertificateRequest to "true" and certManager parameters to use cert-manager and acme challenge
+  certManagerCertificateRequest: false
+  certManager:
+    clusterIssuer: letsencrypt-c3s # Cluster issuer to use for SSL certificates
+    issueTemporaryCertificate: false # Set to true to issue a temporary certificate
+    acme: true # Set to true to use ACME for certificate issuance
+    disableSslRedirect: false # Set to true to disable SSL redirect 

--- a/wms-ready-application/values/windstorm-indicators/values-default.yaml
+++ b/wms-ready-application/values/windstorm-indicators/values-default.yaml
@@ -1,0 +1,31 @@
+# Name of application
+name: windstorm-indicators # Name of application
+localDevelopment: false
+webapp:
+  image: eccr.ecmwf.int/c3s-applications/windstorm-indicators-webapp  # image for application
+  tag: latest # image tag to use (this )
+  port: 80  # Port exposed by the application
+  replicas: 1
+apiServer:
+  image: eccr.ecmwf.int/c3s-applications/windstorm-indicators-server  # image for application
+  tag: latest  # image tag to use (this )
+  port: 5000 # Port exposed by the application
+  replicas: 1
+  env:
+    wmsServer: https://ecds-dev.bopen.compute.cci2.ecmwf.int/c3s-apps/windstorm-indicators/wms
+    rootPath: /c3s-apps/windstorm-indicators/api
+    mode: production
+wms:
+  replicas: 0
+# Values used for ingress control
+ingress:
+  enable: true
+  # Hostname where the app will be published, this must be mapped to the cluster described by the KUBECONFIG
+  hostname: ecds-dev.bopen.compute.cci2.ecmwf.int 
+  # Path to the application, this must be included in the env when building a JS application
+  webappPath: /c3s-apps/windstorm-indicators/
+  apiPath: /c3s-apps/windstorm-indicators/api/ 
+  wmsPath: /c3s-apps/windstorm-indicators/wms/ 
+  # SSL certificate secret name:
+  secretName: cert-manager-c3s-cert
+  ingressclass: nginx-c3s

--- a/wms-ready-application/values/windstorm-indicators/values-prod.yaml
+++ b/wms-ready-application/values/windstorm-indicators/values-prod.yaml
@@ -1,0 +1,31 @@
+# Name of application
+name: windstorm-indicators # Name of application
+localDevelopment: false
+webapp:
+  image: eccr.ecmwf.int/c3s-applications/windstorm-indicators-webapp  # image for application
+  tag: latest # image tag to use (this )
+  port: 80  # Port exposed by the application
+  replicas: 1
+apiServer:
+  image: eccr.ecmwf.int/c3s-applications/windstorm-indicators-server  # image for application
+  tag: latest  # image tag to use (this )
+  port: 5000 # Port exposed by the application
+  replicas: 1
+  env:
+    wmsServer: https://apps.copernicus-climate.eu/c3s-apps/windstorm-indicators/wms
+    rootPath: /c3s-apps/windstorm-indicators/api
+    mode: production
+wms:
+  replicas: 0
+# Values used for ingress control
+ingress:
+  enable: true
+  # Hostname where the app will be published, this must be mapped to the cluster described by the KUBECONFIG
+  hostname: apps.copernicus-climate.eu
+  # Path to the application, this must be included in the env when building a JS application
+  webappPath: /c3s-apps/windstorm-indicators/
+  apiPath: /c3s-apps/windstorm-indicators/api/ 
+  wmsPath: /c3s-apps/windstorm-indicators/wms/ 
+  # SSL certificate secret name:
+  secretName: star.copernicus-climate.eu
+  ingressclass: nginx


### PR DESCRIPTION
cc @EddyCMWF
Now that we have a new application ([windstorm-indicators](https://github.com/c3s-applications/windstorm-indicators-app)) to be deployed we configured the Helm Chart to be as generic as possible for all wms-based application. 

We successfully deployed both ECDE and Windstorm Indicators on our dev cluster with this method. Check here:

- https://ecds-dev.bopen.compute.cci2.ecmwf.int/c3s-apps/ecde/
- https://ecds-dev.bopen.compute.cci2.ecmwf.int/c3s-apps/windstorm-indicators/

This required major changes in the chart structure and the values files management.

We strongly suggest to approve this PR without deleting the current `wms-enabled-application` folder, familiarize with the new method and then delete the previous folder with another PR.